### PR TITLE
Add scheduled Bahn-Mailer workflow

### DIFF
--- a/.github/workflows/bahn-mailer.yml
+++ b/.github/workflows/bahn-mailer.yml
@@ -1,0 +1,27 @@
+name: Bahn-Mailer
+
+on:
+  schedule:
+    - cron: "30 4 * * *"
+    - cron: "30 6 * * *"
+    - cron: "30 8 * * *"
+  workflow_dispatch:
+
+jobs:
+  send-mail:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: pip install -r requirements.txt
+      - run: python scripts/bahn_mailer.py
+        env:
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASS: ${{ secrets.SMTP_PASS }}
+          MAIL_FROM: ${{ secrets.MAIL_FROM }}
+          MAIL_TO:   ${{ secrets.MAIL_TO }}
+          DB_API_KEY: ${{ secrets.DB_API_KEY }}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to send Bahn-Mailer periodically

## Testing
- `git ls-files '*.py' | xargs -r python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_b_6891dca5acb88325b048d3a99c9d05cb