### PR TITLE
Add workflow and script using SMTP secrets

### DIFF
--- a/.github/workflows/send-email.yml
+++ b/.github/workflows/send-email.yml
@@ -1,0 +1,24 @@
+name: Send email
+
+on:
+  workflow_dispatch:
+
+jobs:
+  send:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Send notification
+        env:
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASS: ${{ secrets.SMTP_PASS }}
+          MAIL_FROM: ${{ secrets.MAIL_FROM }}
+          MAIL_TO: ${{ secrets.MAIL_TO }}
+          DB_API_KEY: ${{ secrets.DB_API_KEY }}
+        run: python send_email.py

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # Bahn-News
 Ich lasse mir morgen von Montag - Donnerstag um 07:30, 09:30 und 11:30 die Züge von Köln nach Montabaur auf Ausfälle etc. checken.
+
+## GitHub Actions
+
+Dieses Repository enthält einen Workflow, der Benachrichtigungen über SMTP versendet. Damit er funktioniert, müssen in den Repository-Einstellungen folgende Secrets hinterlegt sein:
+
+- `SMTP_HOST`
+- `SMTP_PORT`
+- `SMTP_USER`
+- `SMTP_PASS`
+- `MAIL_FROM`
+- `MAIL_TO`
+- `DB_API_KEY` (optional)
+
+Im Workflow wird auf diese Werte über die Syntax `${{ secrets.NAME }}` zugegriffen.

--- a/send_email.py
+++ b/send_email.py
@@ -1,0 +1,29 @@
+import os
+import smtplib
+from email.message import EmailMessage
+
+
+def main():
+    smtp_host = os.environ["SMTP_HOST"]
+    smtp_port = int(os.environ.get("SMTP_PORT", "587"))
+    smtp_user = os.environ["SMTP_USER"]
+    smtp_pass = os.environ["SMTP_PASS"]
+    mail_from = os.environ["MAIL_FROM"]
+    mail_to = os.environ["MAIL_TO"]
+    db_api_key = os.environ.get("DB_API_KEY")
+
+    msg = EmailMessage()
+    msg["Subject"] = "Bahn-News notification"
+    msg["From"] = mail_from
+    msg["To"] = mail_to
+    body = "DB API key configured." if db_api_key else "No DB API key configured."
+    msg.set_content(body)
+
+    with smtplib.SMTP(smtp_host, smtp_port) as server:
+        server.starttls()
+        server.login(smtp_user, smtp_pass)
+        server.send_message(msg)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python script that sends a notification using SMTP credentials from environment variables
- create GitHub Actions workflow mapping repository secrets to the script's environment variables
- document required secrets in README

## Testing
- `python -m py_compile send_email.py`


------
https://chatgpt.com/codex/tasks/task_b_6891dca6d4308325b6e3e363ff97de27